### PR TITLE
Změna modu - bug fix + test

### DIFF
--- a/src/SkautIS/SkautIS.php
+++ b/src/SkautIS/SkautIS.php
@@ -204,7 +204,6 @@ class SkautIS {
             self::$instance->setAppId($appId);
         }
 
-        // FIXME: Kdyz se vola getInstance ve vice mistech aplikace jednou $testMode=true a jednou = false, dochazi ke kolizi a problemum viz __get()
         self::$instance->setTestMode($testMode);
 
         return self::$instance;
@@ -222,11 +221,16 @@ class SkautIS {
 
         $wsdlName = $this->getWsdl($name);
 
-        if (!isset($this->active[$wsdlName])) {
-            $wsdl = ($this->isTestMode ? self::HTTP_PREFIX_TEST : self::HTTP_PREFIX) . ".skaut.cz/JunakWebservice/" . $wsdlName . ".asmx?WSDL";
-            $this->active[$wsdlName] = new WS($wsdl, $this->perStorage->init, $this->compression);
+        $wsdlKey = $wsdlName;
+        if ($this->isTestMode) {
+            $wsdlKey .= '_Test';
         }
-        return $this->active[$wsdlName];
+
+        if (!isset($this->active[$wsdlKey])) {
+            $wsdl = $this->getHttpPrefix() . ".skaut.cz/JunakWebservice/" . $wsdlName . ".asmx?WSDL";
+            $this->active[$wsdlKey] = new WS($wsdl, $this->perStorage->init, $this->compression);
+        }
+        return $this->active[$wsdlKey];
     }
 
     /**

--- a/tests/SkautIS/SkautISTest.php
+++ b/tests/SkautIS/SkautISTest.php
@@ -27,4 +27,20 @@ class SkautISTest extends \PHPUnit_Framework_TestCase {
         }
     }
 
+    public function test__get() {
+
+        $skautIS = \SkautIS\SkautIS::getInstance("123");
+
+
+        $skautIS->setTestMode(true);
+        $userA = $skautIS->user;
+        $this->assertSame($userA, $skautIS->user);
+
+        $skautIS->setTestMode(false);
+        $this->assertNotSame($userA, $skautIS->user);
+
+        $skautIS->setTestMode(true);
+        $this->assertSame($userA, $skautIS->user);
+    }
+
 }


### PR DESCRIPTION
Fixnutý problém:
Pokud se změní v průběhu test mode -> ostra verze, nebo naopak, projeví se to jen na WS které dosud nebyly použity. 

příklady:

```
$skautIS = \SkautIS\Skautis::getInstance("appID", true);
$skautIS->UserManagement;

// jinde v aplikaci
$skautIS = \SkautIS\Skautis::getInstance("appID", false);
$skautIS->UserManagement; // WS na testovaci verzi skautISu
$skautIS->OrganizationUnit; // WS na ostrou verzi skautISu
```

```
$skautIS = \SkautIS\Skautis::getInstance("appID", true);
$skautIS->UserManagement;

$skautIS->setTestMode(false);
$skautIS->UserManagement; // WS na testovaci verzi skautISu
$skautIS->OrganizationUnit; // WS na ostrou verzi skautISu
```
