### PR TITLE
Vyuziti skautIS_DateLogout ziskane pri loginu

### DIFF
--- a/src/Skautis.php
+++ b/src/Skautis.php
@@ -278,9 +278,9 @@ class Skautis {
         if ($wsFactory === NULL) {
             $this->wsFactory = new BasicWSFactory();
         }
-
-
-
+	else {
+	    $this->wsFactory = $wsFactory;
+	}
 
 
 

--- a/src/Skautis.php
+++ b/src/Skautis.php
@@ -24,6 +24,7 @@ class Skautis {
     const TOKEN = "ID_Login";
     const ID_ROLE = "ID_Role";
     const ID_UNIT = "ID_Unit";
+    const LOGOUT_DATE = "LOGOU_Date";
     const HTTP_PREFIX_TEST = "http://test-is";
     const HTTP_PREFIX = "https://is";
     CONST SESSION_ID = "skautis_library_data";
@@ -195,6 +196,30 @@ class Skautis {
     }
 
     /**
+     * Vraci datum a cas automaticeho odhlaseni z is.skaut.cz
+     *
+     * @return \DateTime
+     */
+    public function getLogoutDate() {
+        return isset($this->perStorage->data[self::LOGOUT_DATE]) ? $this->perStorage->data[self::LOGOUT_DATE] : NULL;
+    }
+
+    /**
+     *
+     * Nastavi cas automatickeho odhlaseni z is.skaut.cz
+     *
+     * @param \DateTime $logoutDate
+     *
+     * @return void
+     */
+    public function setLogoutDate(\DateTime $logoutDate) {
+        $this->perStorage->data[self::LOGOUT_DATE] = $logoutDate;
+        $this->writeConfigToSession();
+        return $this;
+    }
+
+
+    /**
      * nastavuje trvalé úložiště
      *
      * @throws InvalidArgumentException
@@ -355,6 +380,14 @@ class Skautis {
     public function getLogoutUrl() {
         return $this->getHttpPrefix() . ".skaut.cz/Login/LogOut.aspx?appid=" . $this->getAppId() . "&token=" . $this->getToken();
     }
+    /**
+     * vrací url k registraci
+     * @return string url
+     */
+    public function getRegisterUrl() {
+        return $this->getHttpPrefix() . ".skaut.cz/Login/Registration.aspx?appid=" . $this->getAppId() . (isset($backlink) ? "&ReturnUrl=" . $backlink : "");
+    }
+
 
     /**
      * vrací začátek URL adresy
@@ -366,16 +399,36 @@ class Skautis {
 
     /**
      * kontoluje jestli je přihlášení platné
+     *
+     * @param bool $hardCheck Vynuti kontrolu prihlaseni na serveru
      * @return bool
      */
-    public function isLoggedIn() {
-        try {
-            $this->updateLogoutTime();
-        } catch (Exception $ex) {
+    public function isLoggedIn($hardCheck = FALSE) {
+
+       if (!$hardCheck) {
+
+       if (empty($this->perStorage->init[self::APP_ID]))
+           return FALSE;
+
+
+        if (empty($this->perStorage->init[self::TOKEN]))
             return FALSE;
+
+        if ($this->getLogoutDate()->getTimestamp() < time())
+            return FALSE;
+
+
+            return TRUE;
         }
+
+        try {
+             $this->updateLogoutTime();
+        } catch (Exception $ex) {
+             return FALSE;
+        }
+
         return TRUE;
-    }
+      }
 
     /**
      * prodloužení přihlášení o 30 min
@@ -393,12 +446,25 @@ class Skautis {
     }
 
     /**
-     * hromadne nastaveni po prihlaseni
+     * Hromadne nastaveni po prihlaseni
+     *
+     * @param array $data Pole dat zaslanych skautisem (napriklad $_SESSION)
      */
-    public function setLoginData($token = NULL, $roleId = NULL, $unitId = NULL) {
-        $this->setToken($token);
-        $this->setRoleId($roleId);
-        $this->setUnitId($unitId);
+    public function setLoginData(array $data) {
+
+        if (isset($data['skautIS_Token']))
+            $this->setToken($data['skautIS_Token']);
+
+        if (isset($data['skautIS_IDRole']))
+            $this->setRoleId($data['skautIS_IDRole']);
+
+        if (isset($data['skautIS_IDUnit']))
+            $this->setUnitId($data['skautIS_IDUnit']);
+
+        if (isset($data['skautIS_DateLogout'])) {
+	    $logoutDate = \DateTime::createFromFormat('j. n. Y H:i:s', $data['skautIS_DateLogout']);
+	    $this->setLogoutDate($logoutDate);
+        }
     }
 
     /**

--- a/tests/Skautis/SkautisTest.php
+++ b/tests/Skautis/SkautisTest.php
@@ -134,6 +134,26 @@ class SkautisTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($skautIS->isLoggedIn(true));
     }
 
+    public function testResetLoginData() {
+	$data = array(
+            'skautIS_Token' => "token",
+            'skautIS_IDRole' => 33,
+	    'skautIS_IDUnit' => 100,
+	    'skautIS_DateLogout' => '2. 12. 2014 23:56:02'
+	);
+
+	$skautis = new Skautis();
+
+	$skautis->setLoginData($data);
+	$this->assertEquals(33, $skautis->getRoleId());
+
+	$skautis->resetLoginData();
+        $this->assertEmpty($skautis->getToken());
+        $this->assertEmpty($skautis->getRoleId());
+	$this->assertEmpty($skautis->getUnitId());
+	$this->assertNull($skautis->getLogoutDate());
+    }
+
     /**
      * @runInSeparateProcess
      */

--- a/tests/Skautis/SkautisTest.php
+++ b/tests/Skautis/SkautisTest.php
@@ -78,11 +78,22 @@ class SkautisTest extends \PHPUnit_Framework_TestCase {
 
     public function testSetLoginData() {
         $skautIS = new Skautis();
-        $skautIS->setLoginData("token", 33, 100);
+	$data = array(
+            'skautIS_Token' => "token",
+            'skautIS_IDRole' => 33,
+	    'skautIS_IDUnit' => 100,
+	    'skautIS_DateLogout' => '2. 12. 2014 23:56:02'
+	);
+        $skautIS->setLoginData($data);
         $this->assertEquals("token", $skautIS->getToken());
         $this->assertEquals(33, $skautIS->getRoleId());
-        $this->assertEquals(100, $skautIS->getUnitId());
+	$this->assertEquals(100, $skautIS->getUnitId());
 
+	$this->assertEquals("2014-12-02 23:56:02", $skautIS->getLogoutDate()->format('Y-m-d H:i:s'));
+    }
+
+    public function testSetLoginDataViaSetters() {
+        $skautIS = new Skautis();
         $skautIS->setUnitId(11);
         $this->assertEquals(11, $skautIS->getUnitId());
 
@@ -91,14 +102,26 @@ class SkautisTest extends \PHPUnit_Framework_TestCase {
 
         $skautIS->setUnitId(200);
         $this->assertEquals(200, $skautIS->getUnitId());
+    }
 
-        $skautIS->resetLoginData();
-        $this->assertNull($skautIS->getToken());
-        $this->assertEquals(0, $skautIS->getRoleId());
-        $this->assertEquals(0, $skautIS->getUnitId());
+    public function testIsLoggedInNoInicialization() {
+        $skautIS = new Skautis();
+
+        $this->assertFalse($skautIS->isLoggedIn());
     }
 
     public function testIsLoggedIn() {
+        $skautIS = new Skautis("ad123");
+	$skautIS->setToken("token");
+
+	$skautIS->setLogoutDate(new \DateTime('yesterday'));
+	$this->assertFalse($skautIS->isLoggedIn());
+
+	$skautIS->setLogoutDate(new \DateTime('tomorrow'));
+        $this->assertTrue($skautIS->isLoggedIn());
+    }
+
+    public function testIsLoggedHardCheck() {
         $ws = \Mockery::mock("\Skautis\WS");
         $ws->shouldReceive("LoginUpdateRefresh")->once()->andReturn();
 
@@ -107,9 +130,11 @@ class SkautisTest extends \PHPUnit_Framework_TestCase {
         $factory->shouldReceive("createWS")->with()->once()->andReturn($ws);
 
         $skautIS = new Skautis("ad123");
-        $skautIS->setWSFactory($factory);
+	$skautIS->setWSFactory($factory);
+	$skautIS->setToken("tooken");
+	$skautIS->setLogoutDate(new \DateTime('tomorrow'));
 
-        $this->assertTrue($skautIS->isLoggedIn());
+        $this->assertTrue($skautIS->isLoggedIn(true));
     }
 
     /**


### PR DESCRIPTION
isLoggedIn - Kontrola prihlaseni 1x pote pouze na vyzdani (zkontrolovat zda je to bezpecne)
setLoginData - bere pole, takze tomu lze predat $_SESSION
setLogoutDate - prijima \DateTime, pokud ho uzivatel nechce parsovat at pouzije setLoginData
getLogoutDate - vraci \DateTime
getRegisterUrl - vraci url pro registraci na (test-)is.skaut.cz
