### PR TITLE
Testing HHVM s TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: php
+
 php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
 
-before_script:
+matrix:
+  allow_failures:
+    - php: hhvm
+
+before_install:
   - composer self-update
+
+install:
   - composer install -o --dev --prefer-source
 
 script: phpunit

--- a/tests/Unit/SessionAdapterTest.php
+++ b/tests/Unit/SessionAdapterTest.php
@@ -75,7 +75,7 @@ class SessionAdaptersTest extends \PHPUnit_Framework_TestCase {
 
 	$data = session_encode();
         session_unset();
-	$this->assertCount(0, $_SESSION);
+	$this->assertCount(0, (array)$_SESSION);
 
 	session_decode($data);
 	$this->assertCount(1, $_SESSION);


### PR DESCRIPTION
Kdyz SkautisNette testuje pro HHVM asi by davalo smysl aby i samotna knihovna byla testovana na HHVM.
- before_script prepsan na before_install
- instalace balicku composerem presunuta do install
