### PR TITLE
CacheDecorator: optimalizace ověřování platného LoginID

### DIFF
--- a/src/Wsdl/Decorator/Cache/CacheDecorator.php
+++ b/src/Wsdl/Decorator/Cache/CacheDecorator.php
@@ -2,6 +2,7 @@
 
 namespace Skautis\Wsdl\Decorator\Cache;
 
+use Skautis\User;
 use Skautis\Wsdl\Decorator\AbstractDecorator;
 use Skautis\Wsdl\WebServiceInterface;
 
@@ -13,10 +14,14 @@ class CacheDecorator extends AbstractDecorator
     protected $cache;
 
     /**
-     * @var bool
+     * @var array
      */
-    protected $succesfullRequest;
+    protected static $checkedLoginIds = array();
 
+    /**
+     * @param WebServiceInterface $webService
+     * @param CacheInterface $cache
+     */
     public function __construct(WebServiceInterface $webService, CacheInterface $cache)
     {
         $this->webService = $webService;
@@ -31,10 +36,10 @@ class CacheDecorator extends AbstractDecorator
         $callHash = $this->hashCall($functionName, $arguments);
 
         // Pozaduj alespon 1 supesny request na server (zadna Exception)
-        if (!$this->succesfullRequest) {
+        if (isset($arguments[User::ID_LOGIN]) && !in_array($arguments[User::ID_LOGIN], static::$checkedLoginIds)) {
             $response = $this->webService->call($functionName, $arguments);
             $this->cache->set($callHash, $response);
-            $this->succesfullRequest = true;
+            static::$checkedLoginIds[] = $arguments[User::ID_LOGIN];
 
             return $response;
         }

--- a/tests/Unit/CacheDecoratorTest.php
+++ b/tests/Unit/CacheDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Skautis;
 
+use Skautis\User;
 use Skautis\Wsdl\Decorator\Cache\ArrayCache;
 use Skautis\Wsdl\Decorator\Cache\CacheDecorator;
 
@@ -16,7 +17,7 @@ class CacheDecoratorTest extends \PHPUnit_Framework_TestCase
     public function testDecoratorRequireRequest()
     {
         $value = ['id' => 'response'];
-        $args = ['asd', 'uv'];
+        $args = ['asd', 'uv', User::ID_LOGIN => 'a'];
 
         /** @var Skautis\Wsdl\WebServiceInterface */
         $webService = \Mockery::mock('Skautis\Wsdl\WebServiceInterface');
@@ -30,19 +31,16 @@ class CacheDecoratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($value, $response);
 
 
-        //Stejny request jina odpoved
-        $valueB = ['id' => 'Different response'];
-
+        //Jina instance WS
         /** @var Skautis\Wsdl\WebServiceInterface */
         $webServiceB = \Mockery::mock('Skautis\Wsdl\WebServiceInterface');
-        $webServiceB->shouldReceive('call')->with('funkceA', $args)->once()->andReturn($valueB);
 
         //Cache naplnena z prechoziho requestu
         $decoratedServiceB = new CacheDecorator($webServiceB, $cache);
         $response = $decoratedServiceB->call('funkceA', $args);
 
-        //Jelikoz tato instance provadi prvni request, nevrati data z Cache
-        $this->assertEquals($valueB, $response);
+        //Vraci data z cache
+        $this->assertEquals($value, $response);
     }
 
     public function testDecorator()


### PR DESCRIPTION
- U anonymních WS není potřeba dělat ani jeden dotaz na skautIS a může se vracet rovnou výsledek z cache.
- Pro ověření platnosti LoginID stačí jeden úspěšný požadavek na server pro každé LoginID napříč celou aplikací.
