### PR TITLE
[WIP] Konkrétní výjimky pro WSDL chyby 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
     "autoload": {
         "psr-4": {
             "Skautis\\": "src/"
-        }
+        },
+        "classmap": [
+            "src/Wsdl/exceptions.php"
+        ]
     },
     "suggest": {
         "skautis/nette": "Integrace Skautis do Nette",

--- a/src/Wsdl/exceptions.php
+++ b/src/Wsdl/exceptions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Skautis\Wsdl\Event
+{
+
+	use Skautis\Wsdl\WsdlException;
+
+	class LeaderNotAdultException extends WsdlException {}
+
+	class AssistantNotAdultException extends WsdlException {}
+
+}


### PR DESCRIPTION
Snad každý má v případě chyby v komunikaci wsdl potřebu zjistit konkrétní chybu. Momentálně je třeba si regulárem/strpos apod. vyparsovat název chyby z $e->getMessage(). Bylo by fajn, kdyby bylo možné rovnou poznat o jakou výjimku se jedná = mít pojmenované výjimky.

Tady je nástřel jednoduché implementace. Výjimky dědí od WsdlException a ponechávají stejně properties, takže je to i zpětně kompatibilní řešení.
