### PR TITLE
Oprava typehintu

### DIFF
--- a/src/EventDispatcher/EventDispatcherInterface.php
+++ b/src/EventDispatcher/EventDispatcherInterface.php
@@ -8,7 +8,7 @@ interface EventDispatcherInterface
     /**
      * Přidá listener na událost.
      *
-     * @param string $eventName
+     * @param int $eventName
      * @param callable $callback
      */
     public function subscribe($eventName, callable $callback);

--- a/src/EventDispatcher/EventDispatcherTrait.php
+++ b/src/EventDispatcher/EventDispatcherTrait.php
@@ -10,7 +10,7 @@ trait EventDispatcherTrait
 
 
     /**
-     * @param string|null $eventName
+     * @param int|null $eventName
      * @return bool
      */
     protected function hasListeners($eventName = null)
@@ -19,7 +19,7 @@ trait EventDispatcherTrait
     }
 
     /**
-     * @param string $eventName
+     * @param int $eventName
      * @param mixed $data
      */
     protected function dispatch($eventName, $data)

--- a/src/Wsdl/WsdlManager.php
+++ b/src/Wsdl/WsdlManager.php
@@ -188,7 +188,7 @@ class WsdlManager
     /**
      * Přidá listener na spravovaných vytvářených webových služeb.
      *
-     * @param string $eventName
+     * @param int $eventName
      * @param callable $callback
      */
     public function addWebServiceListener($eventName, callable $callback)


### PR DESCRIPTION
`eventName` má všude typehint `string`, ale vždy se pracuje pouze s `int` (`Webservice::EVENT_SUCCESS` a `Webservice::EVENT_FAILURE`)