### PR TITLE
Update PHP na >= 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ php:
   - 7.2
   - 7.3
   - nightly
-  - hhvm
 
 matrix:
   allow_failures:
     - php: nightly
-    - php: hhvm
 
 before_install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
   - nightly
   - hhvm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Číslování verzí je od verze 2.0.0 v souladu se [Sématinckým verzováním](http://semver.org/)
 
+## Verze 3.x
+
+### v3.0.0
+* Požadována verze PHP >=7.1
+
 ## Verze 2.x
 
 ### v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### v3.0.0
 * Požadována verze PHP >=7.1
+* Odstranění podpory pro HHVM (HHVM dále [nedodržuje kompabilitu s PHP](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html))
 
 ## Verze 2.x
 

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ $skautis->org->unitAll(array("ID_UnitParent"=>$myUnitId))
 Podrobný návod v [dokumentaci](docs/README.md).
 
 ## Požadavky
-PHP 5.6 a novější. Detaily v [composer.json](./composer.json)
+PHP 7.1 a novější. Detaily v [composer.json](./composer.json)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "source": "https://github.com/skaut/Skautis"
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "ext-soap": "*"
     },
     "require-dev": {


### PR DESCRIPTION
PHP 5.6 a 7.0 jsou end-of-life. HHVM ruší kompabilitu s PHP.

Navrhuji nechat 2.x s podporou 5.6 a vyžadovat 7.1 pro 3.x. Nová major verze umožní přidat type hinty do API (https://github.com/skaut/Skautis/issues/71).

Samotné vydání 3.0.0 bych příliš nespěchal - extra čas budu mít až koncem února.