### PR TITLE
check $headers for false value

### DIFF
--- a/src/Wsdl/WsdlManager.php
+++ b/src/Wsdl/WsdlManager.php
@@ -182,7 +182,7 @@ class WsdlManager
     public function isMaintenance()
     {
         $headers = get_headers($this->getWebServiceUrl("UserManagement"));
-        return !in_array('HTTP/1.1 200 OK', $headers);
+        return !$headers || !in_array('HTTP/1.1 200 OK', $headers);
     }
 
     /**


### PR DESCRIPTION
Na základě chyby v logu opravuji. Došlo k tomu v době kdy se aktualizoval skautis.

```
PHP Warning: in_array() expects parameter 2 to be array, boolean given in /.../vendor/skautis/skautis/src/Wsdl/WsdlManager.php:185
```