### PR TITLE
Config -> Immutable object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 * Odstranění podpory pro HHVM (HHVM dále [nedodržuje kompabilitu s PHP](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html))
 * Scalar typehints pro metody
 * [Strict types](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict) - zpětně nekompatibilní
-* Event dispatcher používá string místo int pro ``event name`` - zpětně nekompatibilní
+* ``EventDispatcher`` používá string místo int pro ``event name`` - zpětně nekompatibilní
+* Test mode je nastaven jako defaultní hodnota pro ``Config``, je to tak "bezpečnější" - zpětně nekompatibilní
+* ``Config`` je nyní immutable - zpětně nekompatibilní
 
 ## Verze 2.x
 

--- a/docs/konfigurace.md
+++ b/docs/konfigurace.md
@@ -33,13 +33,13 @@ Veškerá konfigurace je udržována v jediném objektu, který je potřeba vytv
 $applicationId = "moje-application-id";
 
 //Indikátor jestli se má použít test-is.skaut.cz
-$isTestMode = true;
+$isTestMode = Config::TEST_MODE_ENABLED;
 
 //Povol cache pro WSDL
-$cache = $true;
+$cache = Config::CACHE_ENABLED;
 
 //Povol kompresi pro data přenášená ze SkautISu
-$compression = true;
+$compression = Config::COMPRESSION_ENABLED;
 
 $config = new Skautis\Config($applicationId, $isTestMode, $cache, $compression);
 ```

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,14 +6,14 @@ namespace Skautis;
 /**
  * Třída pro uživatelské nastavení
  */
-class Config
+final class Config
 {
 
     public const CACHE_ENABLED = true;
     public const CACHE_DISABLED = false;
 
-    public const TESTMODE_ENABLED = true;
-    public const TESTMODE_DISABLED = false;
+    public const TEST_MODE_ENABLED = true;
+    public const TEST_MODE_DISABLED = false;
 
     public const COMPRESSION_ENABLED = true;
     public const COMPRESSION_DISABLED = false;
@@ -57,7 +57,7 @@ class Config
      */
     public function __construct(
       string $appId,
-      bool $isTestMode = self::TESTMODE_DISABLED,
+      bool $isTestMode = self::TEST_MODE_ENABLED,
       bool $cache = self::CACHE_ENABLED,
       bool $compression = self::COMPRESSION_ENABLED
     ) {
@@ -65,9 +65,9 @@ class Config
             throw new InvalidArgumentException('AppId cannot be empty.');
         }
         $this->appId = $appId;
-        $this->setTestMode($isTestMode);
-        $this->setCache($cache);
-        $this->setCompression($compression);
+        $this->testMode = $isTestMode;
+        $this->cache = $cache;
+        $this->compression = $compression;
     }
 
     public function getAppId(): string
@@ -80,44 +80,20 @@ class Config
         return $this->testMode;
     }
 
-    public function setTestMode(bool $isTestMode = true): self
-    {
-        $this->testMode = $isTestMode;
-        return $this;
-    }
-
     /**
      * Zjistí, jestli je WSDL cachované
      */
-    public function getCache(): bool
+    public function isCacheEnabled(): bool
     {
         return $this->cache;
     }
 
     /**
-     * Vypne/zapne cachovaní WSDL
-     */
-    public function setCache(bool $enabled): self
-    {
-        $this->cache = $enabled;
-        return $this;
-    }
-
-    /**
      * Zjistí, jestli se používá komprese dotazů na WSDL
      */
-    public function getCompression(): bool
+    public function isCompressionEnabled(): bool
     {
         return $this->compression;
-    }
-
-    /**+
-     * Vypne/zapne kompresi dotazů na WSDL
-     */
-    public function setCompression(bool $enabled): self
-    {
-        $this->compression = $enabled;
-        return $this;
     }
 
     /**
@@ -130,6 +106,7 @@ class Config
 
     /**
      * Na základě nastavení vrací argumenty pro SoapClient
+     * Neumožňujeme uživateli primo modifikovat options aby byly vzdy validni a kompatibilni se Skautis API
      *
      * @see \SoapClient
      */

--- a/src/HelperTrait.php
+++ b/src/HelperTrait.php
@@ -33,11 +33,13 @@ trait HelperTrait
      */
     public static function getInstance(
       string $appId,
-      bool $testMode = Config::TESTMODE_DISABLED,
+      bool $testMode = Config::TEST_MODE_DISABLED,
       bool $cache = Config::CACHE_DISABLED,
       bool $compression = Config::COMPRESSION_DISABLED
     ): Skautis {
-        if (!isset(self::$instances[$appId])) {
+        $cacheKey = "$appId-$testMode";
+
+        if (!isset(self::$instances[$cacheKey])) {
             $config = new Config(
               $appId,
               $testMode,
@@ -51,9 +53,9 @@ trait HelperTrait
             $sessionAdapter = new SessionAdapter();
             $user = new User($wsdlManager, $sessionAdapter);
 
-            self::$instances[$appId] = new Skautis($wsdlManager, $user);
+            self::$instances[$cacheKey] = new Skautis($wsdlManager, $user);
         }
 
-        return self::$instances[$appId];
+        return self::$instances[$cacheKey];
     }
 }

--- a/src/Wsdl/WsdlManager.php
+++ b/src/Wsdl/WsdlManager.php
@@ -100,7 +100,7 @@ class WsdlManager
     public function getWebService(string $name, ?string $loginId = null): WebServiceInterface
     {
         $name = $this->getWebServiceName($name);
-        $key = $loginId . '_' . $name . ($this->config->isTestMode() ? '_Test' : '');
+        $key = $loginId . '_' . $name;
 
         if (!isset($this->webServices[$key])) {
             $options = $this->config->getSoapOptions();

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -7,67 +7,61 @@ use Skautis\Config;
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testDefaultConfiguration()
+    public function testDefaultConfiguration(): void
     {
-        $config = new Config("asd123");
+        $config = new Config('asd123');
 
-        $this->assertEquals("asd123", $config->getAppId());
-        $this->assertSame(Config::TESTMODE_DISABLED, $config->isTestMode());
-        $this->assertSame(Config::CACHE_ENABLED, $config->getCache());
-        $this->assertSame(Config::COMPRESSION_ENABLED, $config->getCompression());
+        $this->assertEquals('asd123', $config->getAppId());
+        $this->assertTrue($config->isTestMode());
+        $this->assertTrue($config->isCacheEnabled());
+        $this->assertTrue($config->isCompressionEnabled());
     }
 
-    public function testConstructor()
+    public function testTestModeEnabled(): void
     {
-        $config = new Config('sad', true, false, false);
-
-        $this->assertSame('sad', $config->getAppId());
-        $this->assertSame(Config::TESTMODE_ENABLED, $config->isTestMode());
-        $this->assertSame(Config::CACHE_DISABLED, $config->getCache());
-        $this->assertSame(Config::COMPRESSION_DISABLED, $config->getCompression());
+        $config = new Config('asd123', Config::TEST_MODE_ENABLED);
+        $this->assertTrue($config->isTestMode());
     }
 
-    public function testTestMode()
+    public function testTestModeDisabled(): void
     {
-        $config = new Config("asd123");
-
-        $config->setTestMode(Config::TESTMODE_ENABLED);
-        $this->assertSame(Config::TESTMODE_ENABLED, $config->isTestMode());
-
-        $config->setTestMode(Config::TESTMODE_DISABLED);
-        $this->assertSame(Config::TESTMODE_DISABLED, $config->isTestMode());
+        $config = new Config('asd123', Config::TEST_MODE_DISABLED);
+        $this->assertFalse($config->isTestMode());
     }
 
-    public function testCache()
+    public function testCacheEnabled(): void
     {
-        $config = new Config("asd123");
-
-        $config->setCache(Config::CACHE_DISABLED);
-        $this->assertSame(Config::CACHE_DISABLED, $config->getCache());
-
-        $config->setCache(Config::CACHE_ENABLED);
-        $this->assertSame(Config::CACHE_ENABLED, $config->getCache());
+        $config = new Config('asd123', Config::TEST_MODE_ENABLED, Config::CACHE_ENABLED);
+        $this->assertTrue($config->isCacheEnabled());
     }
 
-    public function testCompression()
+    public function testCacheDisabled(): void
     {
-        $config = new Config("asd123");
-
-        $config->setCompression(Config::COMPRESSION_DISABLED);
-        $this->assertSame(Config::COMPRESSION_DISABLED, $config->getCompression());
-
-        $config->setCompression(Config::COMPRESSION_ENABLED);
-        $this->assertSame(Config::COMPRESSION_ENABLED, $config->getCompression());
+        $config = new Config('asd123', Config::TEST_MODE_ENABLED, Config::CACHE_DISABLED);
+        $this->assertFalse($config->isCacheEnabled());
     }
 
-    public function testBaseUrl()
+    public function testCompressionEnabled(): void
     {
-        $config = new Config('sad');
+        $config = new Config('asd123', Config::TEST_MODE_ENABLED, Config::CACHE_DISABLED, Config::COMPRESSION_ENABLED);
+        $this->assertTrue( $config->isCompressionEnabled());
+    }
 
-        $config->setTestMode(Config::TESTMODE_ENABLED);
-        $this->assertContains('test', $config->getBaseUrl());
+    public function testCompressionDisabled(): void
+    {
+        $config = new Config('asd123', Config::TEST_MODE_ENABLED, Config::CACHE_DISABLED, Config::COMPRESSION_DISABLED);
+        $this->assertFalse( $config->isCompressionEnabled());
+    }
 
-        $config->setTestMode(Config::TESTMODE_DISABLED);
-        $this->assertNotContains('test', $config->getBaseUrl());
+    public function testBaseUrlTestModeEnabled(): void
+    {
+        $config = new Config('sad', Config::TEST_MODE_ENABLED);
+        $this->assertStringStartsWith('https://test', $config->getBaseUrl());
+    }
+
+    public function testBaseUrlTestModeDisabled(): void
+    {
+        $config = new Config('sad', Config::TEST_MODE_DISABLED);
+        $this->assertStringStartsWith('https://is.', $config->getBaseUrl());
     }
 }

--- a/tests/Unit/SkautisTest.php
+++ b/tests/Unit/SkautisTest.php
@@ -2,24 +2,38 @@
 
 namespace Test\Skautis;
 
+use PHPUnit_Framework_TestCase;
+use Skautis\Config;
 use Skautis\Skautis;
 
-class SkautisTest extends \PHPUnit_Framework_TestCase
+class SkautisTest extends PHPUnit_Framework_TestCase
 {
 
-    public function testFactorySingletonHybrid()
+    public function testSingletonSameId(): void
     {
-        $skautis = Skautis::getInstance('789qwe');
-        $this->assertInstanceOf('\Skautis\Skautis', $skautis);
-
-        $skautisA = Skautis::getInstance('789qwe');
+        $skautis = Skautis::getInstance('asd');
+        $skautisA = Skautis::getInstance('asd');
         $this->assertSame($skautis, $skautisA);
-
-        $skautisB = Skautis::getInstance('nejake_jine_appid');
-        $this->assertNotSame($skautis, $skautisB);
     }
 
-    public function testEventSetter()
+    public function testSingletonDifferentId(): void
+    {
+        $skautis = Skautis::getInstance('asd');
+        $skautisA = Skautis::getInstance('qwe');
+        $this->assertNotSame($skautis, $skautisA);
+    }
+
+    public function testSingletonTestMode(): void
+    {
+        $appId = 'some-app-id';
+
+        $skautisWithTestMode = Skautis::getInstance($appId, Config::TEST_MODE_ENABLED);
+        $skautisWithoutTestMode = Skautis::getInstance($appId, Config::TEST_MODE_DISABLED);
+
+        $this->assertNotSame($skautisWithTestMode, $skautisWithoutTestMode);
+    }
+
+    public function testEventSetter(): void
     {
         //@TODO
     }

--- a/tests/Unit/WsdlManagerTest.php
+++ b/tests/Unit/WsdlManagerTest.php
@@ -2,50 +2,42 @@
 
 namespace Test\Skautis;
 
+use Mockery;
+use PHPUnit_Framework_TestCase;
 use Skautis\Config;
+use Skautis\Wsdl\WebServiceFactoryInterface;
 use Skautis\Wsdl\WsdlManager;
 use Skautis\Wsdl\WebServiceInterface;
-use Skautis\Wsdl\WebServiceFactory;
 
-class WsdlManagerTest extends \PHPUnit_Framework_TestCase
+class WsdlManagerTest extends PHPUnit_Framework_TestCase
 {
 
-    public function testGetSupportedWebServices()
+    public function testGetSupportedWebServices(): void
     {
-        /** @var \Skautis\Wsdl\WebServiceFactory */
-        $factory = \Mockery::mock('\Skautis\Wsdl\WebServiceFactory');
-        /** @var \Skautis\Confi */
-        $config = \Mockery::mock('\Skautis\Config');
+        /** @var WebServiceFactoryInterface */
+        $factory = Mockery::mock(WebServiceFactoryInterface::class);
+        $config = new Config('asd');
         $manager = new WsdlManager($factory, $config);
 
         $services = $manager->getSupportedWebServices();
-        $this->assertInternalType('array', $services);
         $this->assertTrue(count($services) > 0);
     }
 
-    public function testGetWebService()
+    public function testGetWebService(): void
     {
-        $wsA =  \Mockery::mock(WebServiceInterface::class);
-        $wsB =\Mockery::mock(WebServiceInterface::class);
+        $wsA =  Mockery::mock(WebServiceInterface::class);
+        $wsB = Mockery::mock(WebServiceInterface::class);
 
-        $factory = \Mockery::mock(WebServiceFactory::class);
-        $factory->shouldReceive('createWebService')->withAnyArgs()->twice()->andReturn($wsA, $wsB);
+        $factory = Mockery::mock(WebServiceFactoryInterface::class);
+        $factory->shouldReceive('createWebService')->twice()->andReturn($wsA, $wsB);
+
         $config = new Config('42');
 
         $manager = new WsdlManager($factory, $config);
 
-        $config->setTestMode(true);
-        $eventA = $manager->getWebService('UserManagement');
-        $this->assertSame($eventA, $manager->getWebService('UserManagement'));
-
-        $config->setTestMode(false);
-        $eventB = $manager->getWebService('UserManagement');
-        $this->assertNotSame($eventA, $eventB);
-
-        $config->setTestMode(true);
-        $this->assertSame($eventA, $manager->getWebService('UserManagement'));
-
-        $this->assertSame($wsA, $eventA);
-        $this->assertSame($wsB, $eventB);
+        $this->assertNotSame($wsA, $wsB);
+        $this->assertSame($wsA, $manager->getWebService('UserManagement'));
+        $this->assertSame($wsA, $manager->getWebService('UserManagement'));
+        $this->assertSame($wsB, $manager->getWebService('ApplicationManagement'));
     }
 }


### PR DESCRIPTION
Soucasny ``Config`` umoznuje menit chovani existujiciho ``Skautis`` objektu (appId, test -> ostry, etc.), ale ``Skautis`` si uchovava prihlaseneho uzivatele -> nekonzistentni stav. 

Toto je zpetne **nekompatibilni** zmena. Odstranuje nektere verejne metody a jine prejmenovava.

